### PR TITLE
removed poetry hooks from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,3 @@ repos:
         args: ["--extend-select", "I", "--fix"]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://github.com/python-poetry/poetry
-    rev: "1.8.3"
-    hooks:
-      - id: poetry-check
-      - id: poetry-lock
-        args: ["--no-update"]


### PR DESCRIPTION
Removed the poetry hooks in the pre-commit config file, since it times out the pre-commit integration.